### PR TITLE
Task5

### DIFF
--- a/src/cl/bitonic.cl
+++ b/src/cl/bitonic.cl
@@ -1,4 +1,59 @@
-__kernel void bitonic(__global float* as)
-{
-    // TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#define WORK_GROUP_SIZE 256
+#endif
+
+#line 7
+
+#define READ_TO_LOCAL_MEM() ;
+
+__kernel void bitonic_small_array(__global float* as, unsigned int cur_size, unsigned int size, unsigned int n) {
+    unsigned int local_id = get_local_id(0);
+    unsigned int global_id = get_global_id(0);
+
+    __local float mem[WORK_GROUP_SIZE];
+
+    if (global_id < n) {
+        mem[local_id] = as[global_id];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    int is_sort_ascending = global_id % (2 * size) < size;
+
+    while (cur_size >= 1) {
+
+        if (global_id % (2 * cur_size) < cur_size && global_id + cur_size < n) {
+            float a = mem[local_id];
+            float b = mem[local_id + cur_size];
+            if ((a < b) == is_sort_ascending) {
+            } else {
+                mem[local_id] = b;
+                mem[local_id + cur_size] = a;
+            }
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+        cur_size /= 2;
+    }
+
+    if (global_id < n) {
+        as[global_id] = mem[local_id];
+    }
+}
+
+
+__kernel void bitonic_large_array(__global float* as, unsigned int cur_size, unsigned int size, unsigned int n) {
+    unsigned int global_id = get_global_id(0);
+
+    int is_sort_ascending = global_id % (2 * size) < size;
+
+    if (global_id % (2 * cur_size) < cur_size && global_id + cur_size < n) {
+        float a = as[global_id];
+        float b = as[global_id + cur_size];
+        if ((a < b) == is_sort_ascending) {
+        } else {
+            as[global_id] = b;
+            as[global_id + cur_size] = a;
+        }
+    }
 }

--- a/src/cl/radix.cl
+++ b/src/cl/radix.cl
@@ -1,4 +1,85 @@
-__kernel void radix(__global unsigned int* as)
-{
-    // TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#define RADIX_BITS 4
+#line 7
+
+__kernel void move_numbers(
+        __global unsigned int* a,
+        __global unsigned int *number_count,
+        unsigned int start_bit,
+        unsigned int n) {
+    int global_id = get_global_id(0);
+    if (global_id < n) {
+        unsigned int x = a[global_id];
+        unsigned int val = (x >> start_bit) & ((1 << RADIX_BITS) - 1);
+        number_count[val * n + global_id] = 1;
+    }
+}
+
+
+__kernel void fill_bit_count(
+        __global unsigned int *a,
+        __global unsigned int *number_count_output,
+        unsigned int start_bit,
+        unsigned int n) {
+    int global_id = get_global_id(0);
+    if (global_id < n) {
+        unsigned int x = a[global_id];
+        unsigned int val = (x >> start_bit) & ((1 << RADIX_BITS) - 1);
+        number_count_output[val * n + global_id] = 1;
+    }
+}
+
+__kernel void prefix_sum(
+        __global unsigned int *a,
+        __global unsigned int *block_sums,
+        __global unsigned int *output,
+        __global unsigned int *block_output,
+        int add_block_sums,
+        unsigned int n) {
+    unsigned int local_id = get_local_id(0);
+    unsigned int global_id = get_global_id(0);
+
+    __local unsigned int mem1[WORK_GROUP_SIZE];
+    __local unsigned int result1[WORK_GROUP_SIZE];
+
+    __local unsigned int *mem = mem1;
+    __local unsigned int *result = result1;
+
+    if (global_id < n) {
+        mem[local_id] = result[local_id] = a[global_id];
+    } else {
+        mem[local_id] = result[local_id] = 0;
+    }
+
+    if (add_block_sums && local_id == 0 && global_id && global_id < n) {
+        unsigned int prev_value = block_sums[global_id / WORK_GROUP_SIZE - 1];
+        mem[0] += prev_value;
+        result[0] += prev_value;
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    for (unsigned int step = 1; step < WORK_GROUP_SIZE; step *= 2) {
+        if (local_id >= step) {
+            result[local_id] = mem[local_id] + mem[local_id - step];
+        } else {
+            result[local_id] = mem[local_id];
+        }
+
+        barrier(CLK_LOCAL_MEM_FENCE);
+
+        __local unsigned int *tmp = mem;
+        mem = result;
+        result = tmp;
+    }
+
+    if (global_id < n) {
+        output[global_id] = mem[local_id];
+    }
+
+    if (local_id == 0 && global_id < n) {
+        block_output[global_id / WORK_GROUP_SIZE] = mem[WORK_GROUP_SIZE - 1];
+    }
 }

--- a/src/cl/radix.cl
+++ b/src/cl/radix.cl
@@ -1,20 +1,22 @@
 #ifdef __CLION_IDE__
 #include <libgpu/opencl/cl/clion_defines.cl>
+#define RADIX_BITS 4
 #endif
 
-#define RADIX_BITS 4
 #line 7
 
 __kernel void move_numbers(
         __global unsigned int* a,
+        __global unsigned int* b,
         __global unsigned int *number_count,
         unsigned int start_bit,
         unsigned int n) {
-    int global_id = get_global_id(0);
+    unsigned int global_id = get_global_id(0);
     if (global_id < n) {
         unsigned int x = a[global_id];
         unsigned int val = (x >> start_bit) & ((1 << RADIX_BITS) - 1);
-        number_count[val * n + global_id] = 1;
+        unsigned int move_pos = number_count[val * n + global_id] - 1;
+        b[move_pos] = x;
     }
 }
 
@@ -24,11 +26,13 @@ __kernel void fill_bit_count(
         __global unsigned int *number_count_output,
         unsigned int start_bit,
         unsigned int n) {
-    int global_id = get_global_id(0);
+    unsigned int global_id = get_global_id(0);
     if (global_id < n) {
         unsigned int x = a[global_id];
         unsigned int val = (x >> start_bit) & ((1 << RADIX_BITS) - 1);
-        number_count_output[val * n + global_id] = 1;
+        for (int i = 0; i < (1 << RADIX_BITS); i++) {
+            number_count_output[i * n + global_id] = i == val;
+        }
     }
 }
 

--- a/src/main_bitonic.cpp
+++ b/src/main_bitonic.cpp
@@ -23,6 +23,33 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
+// Only arrays with length of power of 2 are supported
+void bitonic_sort(
+        ocl::Kernel &small_array_kernel,
+        ocl::Kernel &large_array_kernel,
+        const gpu::gpu_mem_32f &mem,
+        unsigned int n,
+        unsigned int work_group_size) {
+
+    unsigned int global_work_size = (n + work_group_size - 1) / work_group_size * work_group_size;
+
+    unsigned int size = 2;
+
+    unsigned int max_size = 2;
+    while (max_size < n) max_size *= 2;
+
+    while (size <= max_size) {
+        unsigned int cur_size = size / 2;
+
+        while (2 * cur_size > work_group_size) {
+            large_array_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), mem, cur_size, size, n);
+            cur_size /= 2;
+        }
+
+        small_array_kernel.exec(gpu::WorkSize(work_group_size, global_work_size), mem, cur_size, size, n);
+        size *= 2;
+    }
+}
 
 int main(int argc, char **argv)
 {
@@ -33,7 +60,7 @@ int main(int argc, char **argv)
     context.activate();
 
     int benchmarkingIters = 10;
-    unsigned int n = 50*1000*1000;
+    unsigned int n = 32 * 1024 * 1024;
     std::vector<float> as(n, 0);
     FastRandom r(n);
     for (unsigned int i = 0; i < n; ++i) {
@@ -52,13 +79,21 @@ int main(int argc, char **argv)
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n/1000/1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-/*
+
     gpu::gpu_mem_32f as_gpu;
     as_gpu.resizeN(n);
 
     {
-        ocl::Kernel bitonic(bitonic_kernel, bitonic_kernel_length, "bitonic");
-        bitonic.compile();
+        unsigned int work_group_size = 256;
+        ocl::Kernel bitonic_small_array_kernel(
+                bitonic_kernel, bitonic_kernel_length, "bitonic_small_array",
+                "-DWORK_GROUP_SIZE=" + to_string(work_group_size));
+        ocl::Kernel bitonic_large_array_kernel(
+                bitonic_kernel, bitonic_kernel_length, "bitonic_large_array",
+                "-DWORK_GROUP_SIZE=" + to_string(work_group_size));
+
+        bitonic_small_array_kernel.compile();
+        bitonic_large_array_kernel.compile();
 
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
@@ -66,10 +101,7 @@ int main(int argc, char **argv)
 
             t.restart(); // Запускаем секундомер после прогрузки данных чтобы замерять время работы кернела, а не трансфер данных
 
-            unsigned int workGroupSize = 128;
-            unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
-            bitonic.exec(gpu::WorkSize(workGroupSize, global_work_size),
-                         as_gpu, n);
+            bitonic_sort(bitonic_small_array_kernel, bitonic_large_array_kernel, as_gpu, n, work_group_size);
             t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
@@ -78,10 +110,16 @@ int main(int argc, char **argv)
         as_gpu.readN(as.data(), n);
     }
 
+    for (int i = 0; i < n - 1; ++i) {
+        if (as[i] > as[i + 1]) {
+            printf("%d %f %f\n", i, as[i], as[i + 1]);
+        }
+//        printf("%f ", as[i]);
+    }
+
     // Проверяем корректность результатов
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
     return 0;
 }

--- a/src/main_radix.cpp
+++ b/src/main_radix.cpp
@@ -23,6 +23,44 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
+gpu::gpu_mem_32u prefix_sum(
+        gpu::gpu_mem_32u &a_gpu,
+        ocl::Kernel &ocl_prefix_sum_kernel,
+        unsigned int n,
+        unsigned int work_group_size) {
+
+    gpu::gpu_mem_32u prefix_sums;
+    prefix_sums.resizeN(n);
+
+    gpu::gpu_mem_32u block_sums;
+    unsigned int block_buffer_size = (n + work_group_size - 1) / work_group_size;
+    block_sums.resizeN(block_buffer_size);
+
+    ocl_prefix_sum_kernel.exec(gpu::WorkSize(work_group_size, n), a_gpu, a_gpu, prefix_sums, block_sums, 0, n);
+
+    if (n <= work_group_size) {
+        return prefix_sums;
+    }
+
+    gpu::gpu_mem_32u block_prefix_sums =
+            prefix_sum(block_sums, ocl_prefix_sum_kernel, block_buffer_size, work_group_size);
+
+    ocl_prefix_sum_kernel.exec(
+            gpu::WorkSize(work_group_size, n), a_gpu, block_prefix_sums, prefix_sums, block_sums, 1, n);
+    return prefix_sums;
+}
+
+
+void radix_sort(
+        gpu::gpu_mem_32u &a_gpu,
+        ocl::Kernel &prefix_sum_kernel,
+        ocl::Kernel &move_numbers_kernel,
+        ocl::Kernel &fill_bit_count_kernel,
+        unsigned int n,
+        unsigned int work_group_size,
+        unsigned int radix_bits) {
+
+}
 
 int main(int argc, char **argv)
 {
@@ -32,8 +70,8 @@ int main(int argc, char **argv)
     context.init(device.device_id_opencl);
     context.activate();
 
-    int benchmarkingIters = 10;
-    unsigned int n = 50*1000*1000;
+    int benchmarkingIters = 1;
+    unsigned int n = 1000;
     std::vector<unsigned int> as(n, 0);
     FastRandom r(n);
     for (unsigned int i = 0; i < n; ++i) {
@@ -52,13 +90,27 @@ int main(int argc, char **argv)
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << (n/1000/1000) / t.lapAvg() << " millions/s" << std::endl;
     }
-/*
+
     gpu::gpu_mem_32u as_gpu;
     as_gpu.resizeN(n);
 
     {
-        ocl::Kernel radix(radix_kernel, radix_kernel_length, "radix");
-        radix.compile();
+        unsigned int work_group_size = 256;
+        unsigned int radix_bits = 4;
+
+        std::cout << "-DWORK_GROUP_SIZE=" + to_string(work_group_size) + " -DRADIX_BITS=" + to_string(radix_bits) << std::endl;
+        ocl::Kernel move_numbers(
+                radix_kernel, radix_kernel_length, "move_numbers",
+                "-DWORK_GROUP_SIZE=" + to_string(work_group_size) + " -DRADIX_BITS=" + to_string(radix_bits));
+        ocl::Kernel prefix_sum(
+                radix_kernel, radix_kernel_length, "prefix_sum", "-DWORK_GROUP_SIZE=" + to_string(work_group_size));
+        ocl::Kernel fill_bit_count(
+                radix_kernel, radix_kernel_length, "fill_bit_count",
+                "-DWORK_GROUP_SIZE=" + to_string(work_group_size) + " -DRADIX_BITS=" + to_string(radix_bits));
+
+        move_numbers.compile();
+        prefix_sum.compile();
+        fill_bit_count.compile();
 
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
@@ -66,10 +118,10 @@ int main(int argc, char **argv)
 
             t.restart(); // Запускаем секундомер после прогрузки данных чтобы замерять время работы кернела, а не трансфер данных
 
-            unsigned int workGroupSize = 128;
-            unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
-            radix.exec(gpu::WorkSize(workGroupSize, global_work_size),
-                       as_gpu, n);
+            radix_sort();
+//            unsigned int global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+//            radix.exec(gpu::WorkSize(workGroupSize, global_work_size),
+//                       as_gpu, n);
             t.nextLap();
         }
         std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
@@ -82,6 +134,5 @@ int main(int argc, char **argv)
     for (int i = 0; i < n; ++i) {
         EXPECT_THE_SAME(as[i], cpu_sorted[i], "GPU results should be equal to CPU results!");
     }
-*/
     return 0;
 }


### PR DESCRIPTION
**Bitonic sort**
```
OpenCL devices:
  Device #0: GPU. GeForce GTX 1060 3GB. Total memory: 3010 Mb
Using device #0: GPU. GeForce GTX 1060 3GB. Total memory: 3010 Mb
Data generated for n=33554432!
CPU: 17.1603+-0.015507 s
CPU: 1.92304 millions/s
GPU: 0.396161+-0.0025801 s
GPU: 83.2994 millions/s
```

**Radix sort**
```
OpenCL devices:
  Device #0: GPU. GeForce GTX 1060 3GB. Total memory: 3010 Mb
Using device #0: GPU. GeForce GTX 1060 3GB. Total memory: 3010 Mb
Data generated for n=33554432!
CPU: 15.2441+-0 s
CPU: 2.16477 millions/s
GPU: 0.773587+-0 s
GPU: 42.6584 millions/s
```

bottleneck в цифровой сортировке -- подсчет префиксных сумм, я их скопипастил из старого дз. К сожалению, при попытке это дело соптимизировать (например, не делать барьеры, когда не нужно), но (в зависимости от изменений) кернел просто крашится. Как Вы сказали в прошлый раз, проблема вероятно в драйверах :(