### PR TITLE
Task3, prefix_sums. Boyarintsev Artem

### DIFF
--- a/src/cl/max_prefix_sum.cl
+++ b/src/cl/max_prefix_sum.cl
@@ -1,1 +1,102 @@
-// TODO
+#ifdef __CLION_IDE__
+#include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+
+#line 6
+
+#define LOCAL_MEMORY_MAX_SIZE 256*3
+
+
+__kernel void max_prefix_sum_prepare(const __global int* global_a, __global int* global_out,
+                    unsigned int size)
+{
+    __local int local_memory[LOCAL_MEMORY_MAX_SIZE];
+
+    int values_per_group = get_local_size(0);
+
+    int localId = get_local_id(0);
+    int globalId = get_global_id(0);
+
+    int groupId = get_group_id(0);
+    int numGroups = get_num_groups(0);
+
+    if (globalId >= size)
+    {
+        local_memory[localId] = 0;
+    }
+    else
+    {
+        local_memory[localId] = global_a[groupId * values_per_group + localId];
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    if (localId == 0)
+    {
+        int sum = 0;
+        int max_sum = -2147000000;
+        int max_sum_index = 0;
+        for (int i = 0; i < values_per_group; ++i)
+        {
+            sum += local_memory[i];
+            if (sum > max_sum)
+            {
+                max_sum = sum;
+                max_sum_index = groupId * values_per_group + i;
+                //printf("%d %d\n", max_sum, max_sum_index);
+            }
+        }
+        global_out[3*groupId] = sum;
+        global_out[3*groupId + 1] = max_sum;
+        global_out[3*groupId + 2] =  max_sum_index;
+    }
+}
+
+
+__kernel void max_prefix_sum_routine(const __global int* global_a, __global int* global_out, unsigned int size)
+{
+    __local int local_memory[LOCAL_MEMORY_MAX_SIZE];
+
+    int values_per_group = get_local_size(0);
+
+    int localId = get_local_id(0);
+    int globalId = get_global_id(0);
+
+    int groupId = get_group_id(0);
+    int numGroups = get_num_groups(0);
+
+    if (globalId >= size)
+    {
+        local_memory[3*localId] = 0;
+        local_memory[3*localId + 1] = 0;
+        local_memory[3*localId + 2] = 0;
+    }
+    else
+    {
+        local_memory[3 * localId] = global_a[3 * globalId];
+        local_memory[3 * localId + 1] = global_a[3 * globalId + 1];
+        local_memory[3 * localId + 2] = global_a[3 * globalId  + 2];
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+    if (localId == 0 && globalId < size)
+    {
+        int sum = local_memory[0];
+        int max_sum = local_memory[1];
+        int max_sum_index = local_memory[2];
+        for (int i = 1; i < values_per_group; ++i)
+        {
+            int sum_and_max = sum + local_memory[3 * i + 1];
+            if (sum_and_max > max_sum)
+            {
+                max_sum = sum_and_max;
+                max_sum_index = local_memory[3 * i + 2];
+            }
+            sum += local_memory[3 * i];
+        }
+
+        global_out[3*groupId] = sum;
+        global_out[3*groupId + 1] = max_sum;
+        global_out[3*groupId + 2] = max_sum_index;
+    }
+}


### PR DESCRIPTION
В третьем задании, вы у меня приняли фрактал Мандельброта и обычное суммирование, а префиксное суммирование я не сделал нормально вовремя. Но сейчас получилось.
Вот вывод :
```OpenCL devices:
  Device #0: GPU. GeForce GTX 1060 with Max-Q Design. Total memory: 6078 Mb
Using device #0: GPU. GeForce GTX 1060 with Max-Q Design. Total memory: 6078 Mb
______________________________________________
n=1 values in range: [-1023; 1023]
Max prefix sum: 1004 on prefix [0; 1)
CPU: 1.66667e-07+-3.72678e-07 s
CPU: 6 millions/s
GPU: 1.53333e-05+-4.71405e-07 s
GPU: 0.0652174 millions/s
______________________________________________
n=2 values in range: [-1023; 1023]
Max prefix sum: -517 on prefix [0; 2)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 1.6e-05+-5.7735e-07 s
GPU: 0.125 millions/s
______________________________________________
n=4 values in range: [-1023; 1023]
Max prefix sum: 1014 on prefix [0; 2)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 1.61667e-05+-1.06719e-06 s
GPU: 0.247423 millions/s
______________________________________________
n=8 values in range: [-1023; 1023]
Max prefix sum: -887 on prefix [0; 1)
CPU: 1.66667e-07+-3.72678e-07 s
CPU: 48 millions/s
GPU: 1.5e-05+-0 s
GPU: 0.533333 millions/s
______________________________________________
n=16 values in range: [-1023; 1023]
Max prefix sum: 457 on prefix [0; 1)
CPU: 3.33333e-07+-4.71405e-07 s
CPU: 48 millions/s
GPU: 1.51667e-05+-3.72678e-07 s
GPU: 1.05495 millions/s
______________________________________________
n=32 values in range: [-1023; 1023]
Max prefix sum: -51 on prefix [0; 1)
CPU: 8.33333e-07+-3.72678e-07 s
CPU: 38.4 millions/s
GPU: 1.18333e-05+-3.72678e-07 s
GPU: 2.70423 millions/s
______________________________________________
n=64 values in range: [-1023; 1023]
Max prefix sum: 1170 on prefix [0; 17)
CPU: 5e-07+-5e-07 s
CPU: 128 millions/s
GPU: 1.2e-05+-0 s
GPU: 5.33333 millions/s
______________________________________________
n=128 values in range: [-1023; 1023]
Max prefix sum: 4773 on prefix [0; 124)
CPU: 5e-07+-5e-07 s
CPU: 256 millions/s
GPU: 1.33333e-05+-1.59861e-06 s
GPU: 9.6 millions/s
______________________________________________
n=256 values in range: [-1023; 1023]
Max prefix sum: 7649 on prefix [0; 183)
CPU: 1e-06+-0 s
CPU: 256 millions/s
GPU: 1.2e-05+-0 s
GPU: 21.3333 millions/s
______________________________________________
n=512 values in range: [-1023; 1023]
Max prefix sum: 4170 on prefix [0; 52)
CPU: 1.5e-06+-5e-07 s
CPU: 341.333 millions/s
GPU: 3.38333e-05+-9.31695e-06 s
GPU: 15.133 millions/s
______________________________________________
n=1024 values in range: [-1023; 1023]
Max prefix sum: 14708 on prefix [0; 829)
CPU: 3e-06+-0 s
CPU: 341.333 millions/s
GPU: 2.8e-05+-0 s
GPU: 36.5714 millions/s
______________________________________________
n=2048 values in range: [-1023; 1023]
Max prefix sum: 22303 on prefix [0; 1779)
CPU: 6e-06+-0 s
CPU: 341.333 millions/s
GPU: 2.81667e-05+-3.72678e-07 s
GPU: 72.7101 millions/s
______________________________________________
n=4096 values in range: [-1023; 1023]
Max prefix sum: 4292 on prefix [0; 58)
CPU: 1.11667e-05+-3.72678e-07 s
CPU: 366.806 millions/s
GPU: 2.8e-05+-0 s
GPU: 146.286 millions/s
______________________________________________
n=8192 values in range: [-1023; 1023]
Max prefix sum: 3297 on prefix [0; 470)
CPU: 2.2e-05+-4.54747e-13 s
CPU: 372.364 millions/s
GPU: 2.81667e-05+-3.72678e-07 s
GPU: 290.84 millions/s
______________________________________________
n=16384 values in range: [-1023; 1023]
Max prefix sum: 103982 on prefix [0; 10101)
CPU: 4.43333e-05+-4.71405e-07 s
CPU: 369.564 millions/s
GPU: 2.88333e-05+-6.87184e-07 s
GPU: 568.231 millions/s
______________________________________________
n=32768 values in range: [-1023; 1023]
Max prefix sum: 75785 on prefix [0; 2074)
CPU: 8.81667e-05+-3.72678e-07 s
CPU: 371.66 millions/s
GPU: 3.23333e-05+-4.71405e-07 s
GPU: 1013.44 millions/s
______________________________________________
n=65536 values in range: [-1023; 1023]
Max prefix sum: 93500 on prefix [0; 61715)
CPU: 0.000172833+-3.72678e-07 s
CPU: 379.186 millions/s
GPU: 3.83333e-05+-4.71405e-07 s
GPU: 1709.63 millions/s
______________________________________________
n=131072 values in range: [-1023; 1023]
Max prefix sum: 310443 on prefix [0; 102163)
CPU: 0.0003495+-1.60728e-06 s
CPU: 375.027 millions/s
GPU: 6.2e-05+-0 s
GPU: 2114.06 millions/s
______________________________________________
n=262144 values in range: [-1023; 1023]
Max prefix sum: 449686 on prefix [0; 211310)
CPU: 0.000698833+-1.77169e-06 s
CPU: 375.117 millions/s
GPU: 7.78333e-05+-6.87184e-07 s
GPU: 3368.02 millions/s
______________________________________________
n=524288 values in range: [-1023; 1023]
Max prefix sum: 18511 on prefix [0; 470827)
CPU: 0.00137717+-1.86339e-06 s
CPU: 380.7 millions/s
GPU: 0.0001115+-5e-07 s
GPU: 4702.13 millions/s
______________________________________________
n=1048576 values in range: [-1023; 1023]
Max prefix sum: 46638 on prefix [0; 12341)
CPU: 0.00280367+-8.28023e-05 s
CPU: 374.002 millions/s
GPU: 0.00025+-6.55871e-05 s
GPU: 4194.3 millions/s
______________________________________________
n=2097152 values in range: [-1023; 1023]
Max prefix sum: 1199401 on prefix [0; 1691780)
CPU: 0.0054985+-5.85235e-06 s
CPU: 381.404 millions/s
GPU: 0.000301+-1e-06 s
GPU: 6967.28 millions/s
______________________________________________
n=4194304 values in range: [-511; 511]
Max prefix sum: 43576 on prefix [0; 3543860)
CPU: 0.0107333+-6.15512e-05 s
CPU: 390.774 millions/s
GPU: 0.000553167+-3.72678e-07 s
GPU: 7582.35 millions/s
______________________________________________
n=8388608 values in range: [-255; 255]
Max prefix sum: 262168 on prefix [0; 2631415)
CPU: 0.021032+-0.000166447 s
CPU: 398.85 millions/s
GPU: 0.0010655+-7.63763e-07 s
GPU: 7872.93 millions/s
______________________________________________
n=16777216 values in range: [-127; 127]
Max prefix sum: 79474 on prefix [0; 976207)
CPU: 0.0423158+-0.000379976 s
CPU: 396.476 millions/s
GPU: 0.0020845+-7.63763e-07 s
GPU: 8048.56 millions/s```