### PR TITLE
Суворов Егор, HSE, Task 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,13 @@ cmake_install.cmake
 compile_commands.json
 libs/
 nbproject/
+
+*.vcxproj
+*.vcxproj.filters
+*.vcxproj.user
+*.sln
+*.opensdf
+*.sdf
+Debug/
+/x64/
+/.vs

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ Debug/
 /x64/
 /.vs
 *.png
+/*.dir

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ nbproject/
 Debug/
 /x64/
 /.vs
+*.png

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,12 @@
 **/*_cl.h
+
+build/
+CMakeCache.txt
+CMakeFiles/
+Makefile
+*.exe
+
+cmake_install.cmake
+compile_commands.json
+libs/
+nbproject/

--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -7,12 +7,10 @@
 #define threshold 256.0f
 #define threshold2 (threshold * threshold)
 
-__kernel void mandelbrot(__global float *results, float fromX, float fromY, float sizeX, float sizeY, unsigned int iters, unsigned int smoothing)
+__kernel void mandelbrot(__global float *results, int width, int height, float fromX, float fromY, float sizeX, float sizeY, unsigned int iters, unsigned int smoothing)
 {
 	int i = get_global_id(0);
 	int j = get_global_id(1);
-	unsigned int width = get_global_size(0);
-	unsigned int height = get_global_size(1);
 
 	float x0 = fromX + (i + 0.5f) * sizeX / width;
 	float y0 = fromY + (j + 0.5f) * sizeY / height;

--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -4,8 +4,38 @@
 
 #line 6
 
-__kernel void mandelbrot(...)
+#define threshold 256.0f
+#define threshold2 (threshold * threshold)
+
+__kernel void mandelbrot(__global float *results, float fromX, float fromY, float sizeX, float sizeY, unsigned int iters, unsigned int smoothing)
 {
+	int i = get_global_id(0);
+	int j = get_global_id(1);
+	unsigned int width = get_global_size(0);
+	unsigned int height = get_global_size(1);
+
+	float x0 = fromX + (i + 0.5f) * sizeX / width;
+	float y0 = fromY + (j + 0.5f) * sizeY / height;
+
+	float x = x0;
+	float y = y0;
+
+	int iter = 0;
+	for (; iter < iters; ++iter) {
+		float xPrev = x;
+		x = x * x - y * y + x0;
+		y = 2.0f * xPrev * y + y0;
+		if ((x * x + y * y) > threshold2) {
+			break;
+		}
+	}
+	float result = iter;
+	if (smoothing && iter != iters) {
+		result = result - log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+	}
+
+	result = 1.0f * result / iters;
+	results[j * width + i] = result;
     // TODO если хочется избавиться от зернистости и дрожжания при интерактивном погружении - добавьте anti-aliasing:
     // грубо говоря при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
     // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя

--- a/src/cl/max_prefix_sum.cl
+++ b/src/cl/max_prefix_sum.cl
@@ -1,5 +1,37 @@
+#define GROUP_SIZE 1024
+
 __kernel void fill_zero(__global int *as) {
 	as[get_global_id(0)] = 0;
+}
+
+__kernel void fill_zero_i(__global int *as, int i) {
+	if (get_global_id(0) == 0) {
+		as[i] = 0;
+	}
+}
+
+__kernel void prefix_sum_fwd_local(__global int *global_prefsum) {
+	int global_i = get_global_id(0);
+	global_i += global_i / GROUP_SIZE * GROUP_SIZE;
+
+	int local_i = get_local_id(0);
+
+	__local int local_prefsum[2 * GROUP_SIZE];
+	local_prefsum[local_i] = global_prefsum[global_i];
+	local_prefsum[local_i + GROUP_SIZE] = global_prefsum[global_i + GROUP_SIZE];
+	barrier(CLK_LOCAL_MEM_FENCE);
+
+	int max_local_i = GROUP_SIZE;
+	for (int step = 1; step <= GROUP_SIZE; step *= 2, max_local_i /= 2) {
+		if (local_i < max_local_i) {
+			int mid_id = local_i * 2 * step + step - 1;
+			int last_id = mid_id + step;
+			local_prefsum[last_id] += local_prefsum[mid_id];
+		}
+		barrier(CLK_LOCAL_MEM_FENCE);
+	}
+	global_prefsum[global_i] = local_prefsum[local_i];
+	global_prefsum[global_i + GROUP_SIZE] = local_prefsum[local_i + GROUP_SIZE];
 }
 
 __kernel void prefix_sum_fwd(__global int *global_prefsum, int n, int step) {
@@ -23,14 +55,37 @@ __kernel void prefix_sum_bwd(__global int *global_prefsum, int n, int step) {
 	int mid_id = start_id + step  -1;
 	int last_id = mid_id + step;
 
-	if (max_id == 1) {
-		global_prefsum[last_id] = 0;
-	}
-
 	int sumL = global_prefsum[mid_id];
 	int toAdd = global_prefsum[last_id];
 	global_prefsum[mid_id] = toAdd;
 	global_prefsum[last_id] += sumL;
+}
+
+__kernel void prefix_sum_bwd_local(__global int *global_prefsum) {
+	int global_i = get_global_id(0);
+	global_i += global_i / GROUP_SIZE * GROUP_SIZE;
+
+	int local_i = get_local_id(0);
+
+	__local int local_prefsum[2 * GROUP_SIZE];
+	local_prefsum[local_i] = global_prefsum[global_i];
+	local_prefsum[local_i + GROUP_SIZE] = global_prefsum[global_i + GROUP_SIZE];
+	barrier(CLK_LOCAL_MEM_FENCE);
+
+	int max_local_i = 1;
+	for (int step = GROUP_SIZE; step >= 1; step /= 2, max_local_i *= 2) {
+		if (local_i < max_local_i) {
+			int mid_id = local_i * 2 * step + step - 1;
+			int last_id = mid_id + step;
+			int sumL = local_prefsum[mid_id];
+			int toAdd = local_prefsum[last_id];
+			local_prefsum[mid_id] = toAdd;
+			local_prefsum[last_id] += sumL;
+		}
+		barrier(CLK_LOCAL_MEM_FENCE);
+	}
+	global_prefsum[global_i] = local_prefsum[local_i];
+	global_prefsum[global_i + GROUP_SIZE] = local_prefsum[local_i + GROUP_SIZE];
 }
 
 __kernel void max_val(__global int *global_as, __global int *global_max_id, int n, int step)

--- a/src/cl/max_prefix_sum.cl
+++ b/src/cl/max_prefix_sum.cl
@@ -1,1 +1,31 @@
-// TODO
+#pragma OPENCL EXTENSION cl_khr_int64_extended_atomics: enable
+
+__kernel void fill_zero(__global int *as) {
+	as[get_global_id(0)] = 0;
+}
+
+__kernel void prefix_sum(__global int *global_prefsum, int n, int step) {
+	int start_id = get_global_id(0) * 2 * step + step;
+	int end_id = start_id + step;
+	if (start_id >= n) return;
+
+	for (int i = start_id; i < end_id; i++) {
+		global_prefsum[i] += global_prefsum[start_id - 1];
+	}
+}
+
+__kernel void max_val(__global int *global_as, __global int *global_max_id, int n, int step)
+{
+	int start_id = get_global_id(0) * 2 * step;
+	int mid_id = start_id + step;
+	if (start_id >= n) return;
+
+	if (step == 1) {
+		global_max_id[start_id] = start_id + 1;
+		global_max_id[mid_id] = mid_id + 1;
+	}
+	if (global_as[mid_id] > global_as[start_id]) {
+		global_as[start_id] = global_as[mid_id];
+		global_max_id[start_id] = global_max_id[mid_id];
+	}
+}

--- a/src/cl/max_prefix_sum.cl
+++ b/src/cl/max_prefix_sum.cl
@@ -2,25 +2,49 @@ __kernel void fill_zero(__global int *as) {
 	as[get_global_id(0)] = 0;
 }
 
-__kernel void prefix_sum(__global int *global_prefsum, int n, int step) {
-	int start_id = get_global_id(0) * 2 * step + step;
-	int end_id = start_id + step;
-	if (start_id >= n) return;
+__kernel void prefix_sum_fwd(__global int *global_prefsum, int n, int step) {
+	int max_id = n / (2 * step);
+	int start_id = get_global_id(0);
+	if (start_id >= max_id) return;
 
-	for (int i = start_id; i < end_id; i++) {
-		global_prefsum[i] += global_prefsum[start_id - 1];
+	start_id = start_id * 2 * step;
+	int mid_id = start_id + step - 1;
+	int last_id = mid_id + step;
+
+	global_prefsum[last_id] += global_prefsum[mid_id];
+}
+
+__kernel void prefix_sum_bwd(__global int *global_prefsum, int n, int step) {
+	int max_id = n / (2 * step);
+	int start_id = get_global_id(0);
+	if (start_id >= max_id) return;
+
+	start_id = start_id * 2 * step;
+	int mid_id = start_id + step  -1;
+	int last_id = mid_id + step;
+
+	if (max_id == 1) {
+		global_prefsum[last_id] = 0;
 	}
+
+	int sumL = global_prefsum[mid_id];
+	int toAdd = global_prefsum[last_id];
+	global_prefsum[mid_id] = toAdd;
+	global_prefsum[last_id] += sumL;
 }
 
 __kernel void max_val(__global int *global_as, __global int *global_max_id, int n, int step)
 {
-	int start_id = get_global_id(0) * 2 * step;
+	int max_id = n / (2 * step);
+	int start_id = get_global_id(0);
+	if (start_id >= max_id) return;
+
+	start_id = start_id * 2 * step;
 	int mid_id = start_id + step;
-	if (start_id >= n) return;
 
 	if (step == 1) {
-		global_max_id[start_id] = start_id + 1;
-		global_max_id[mid_id] = mid_id + 1;
+		global_max_id[start_id] = start_id;
+		global_max_id[mid_id] = mid_id;
 	}
 	if (global_as[mid_id] > global_as[start_id]) {
 		global_as[start_id] = global_as[mid_id];

--- a/src/cl/max_prefix_sum.cl
+++ b/src/cl/max_prefix_sum.cl
@@ -1,5 +1,3 @@
-#pragma OPENCL EXTENSION cl_khr_int64_extended_atomics: enable
-
 __kernel void fill_zero(__global int *as) {
 	as[get_global_id(0)] = 0;
 }

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,23 @@
-// TODO
+#define GROUP_SIZE 1024
+
+__kernel void sum(__global unsigned int *global_as, __global unsigned int *total_sum)
+{
+	int global_i = get_global_id(0);
+	int global_n = get_global_size(0);
+
+	int local_i = get_local_id(0);
+	__local unsigned int local_sums[GROUP_SIZE];
+	local_sums[local_i] = global_as[global_i];
+	barrier(CLK_LOCAL_MEM_FENCE);
+
+	for (int block = 1; block < GROUP_SIZE; block *= 2) {
+		if (local_i % (2 * block) == 0) {
+			local_sums[local_i] += local_sums[local_i + block];
+		}
+		barrier(CLK_LOCAL_MEM_FENCE);
+	}
+
+	if (local_i == 0) {
+		atomic_add(total_sum, local_sums[0]);
+	}
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
 
 		timer t;
 		for (int i = 0; i < benchmarkingIters; ++i) {
-			kernel.exec(gpu::WorkSize(GROUP_SIZE, GROUP_SIZE, width, height), gpu_buffer, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, 0);
+			kernel.exec(gpu::WorkSize(GROUP_SIZE, GROUP_SIZE, width, height), gpu_buffer, width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, 0);
 			t.nextLap();
 		}
 		gpu_buffer.readN(gpu_results.ptr(), width * height);

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -106,40 +106,69 @@ int main(int argc, char **argv)
     }
 
 
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляние на лог,
-//        // передав printLog=true - скорее всего в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float,
-//        // то это означает что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
+    // Раскомментируйте это:
+
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
+    {
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляние на лог,
+        // передав printLog=true - скорее всего в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float,
+        // то это означает что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        bool printLog = false;
+        kernel.compile(printLog);
+        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
+        // результат должен оказаться в gpu_results
+
+	    gpu::shared_device_buffer_typed<cl_float> gpu_buffer;
+		gpu_buffer.resizeN(width * height);
+
+		const int GROUP_SIZE = 32;
+
+		timer t;
+		for (int i = 0; i < benchmarkingIters; ++i) {
+			kernel.exec(gpu::WorkSize(GROUP_SIZE, GROUP_SIZE, width, height), gpu_buffer, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, 0);
+			t.nextLap();
+		}
+		gpu_buffer.readN(gpu_results.ptr(), width * height);
+
+		size_t flopsInLoop = 10;
+		size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+		size_t gflops = 1000 * 1000 * 1000;
+		std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+		std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+
+		double realIterationsFraction = 0.0;
+		for (int j = 0; j < height; ++j) {
+			for (int i = 0; i < width; ++i) {
+				realIterationsFraction += gpu_results.ptr()[j * width + i];
+			}
+		}
+		std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+
+		renderToColor(gpu_results.ptr(), image.ptr(), width, height);
+		image.savePNG("mandelbrot_gpu.png");
+    }
+
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
 
     // Это бонус ввиде интерактивной отрисовки, не забудьте запустить на ГПУ чтобы посмотреть в какой момент числа итераций/точности single float перестанет хватать
     // Кликами мышки можно смещать ракурс

--- a/src/main_max_prefix_sum.cpp
+++ b/src/main_max_prefix_sum.cpp
@@ -20,7 +20,33 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 
 int main(int argc, char **argv)
 {
-    int benchmarkingIters = 10;
+	gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+	gpu::Context context;
+	context.init(device.device_id_opencl);
+	context.activate();
+
+	ocl::Kernel fill_zero(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "fill_zero");
+	fill_zero.compile(/*printLog=*/ false);
+
+	ocl::Kernel fill_zero_i(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "fill_zero_i");
+	fill_zero_i.compile(/*printLog=*/ false);
+
+	ocl::Kernel prefix_sum_fwd_local(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "prefix_sum_fwd_local");
+	prefix_sum_fwd_local.compile(/*printLog=*/ false);
+
+	ocl::Kernel prefix_sum_fwd(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "prefix_sum_fwd");
+	prefix_sum_fwd.compile(/*printLog=*/ false);
+
+	ocl::Kernel prefix_sum_bwd(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "prefix_sum_bwd");
+	prefix_sum_bwd.compile(/*printLog=*/ false);
+
+	ocl::Kernel prefix_sum_bwd_local(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "prefix_sum_bwd_local");
+	prefix_sum_bwd_local.compile(/*printLog=*/ false);
+
+	ocl::Kernel max_val(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "max_val");
+	max_val.compile(/*printLog=*/ false);
+
+	int benchmarkingIters = 10;
     int max_n = (1 << 24);
 
     for (int n = 2; n <= max_n; n *= 2) {
@@ -74,32 +100,6 @@ int main(int argc, char **argv)
         }
 
         {
-			gpu::Device device = gpu::chooseGPUDevice(argc, argv);
-			gpu::Context context;
-			context.init(device.device_id_opencl);
-			context.activate();
-
-			ocl::Kernel fill_zero(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "fill_zero");
-			fill_zero.compile(/*printLog=*/ false);
-
-			ocl::Kernel fill_zero_i(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "fill_zero_i");
-			fill_zero_i.compile(/*printLog=*/ false);
-
-			ocl::Kernel prefix_sum_fwd_local(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "prefix_sum_fwd_local");
-			prefix_sum_fwd_local.compile(/*printLog=*/ false);
-
-			ocl::Kernel prefix_sum_fwd(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "prefix_sum_fwd");
-			prefix_sum_fwd.compile(/*printLog=*/ false);
-
-			ocl::Kernel prefix_sum_bwd(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "prefix_sum_bwd");
-			prefix_sum_bwd.compile(/*printLog=*/ false);
-
-			ocl::Kernel prefix_sum_bwd_local(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "prefix_sum_bwd_local");
-			prefix_sum_bwd_local.compile(/*printLog=*/ false);
-
-			ocl::Kernel max_val(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "max_val");
-			max_val.compile(/*printLog=*/ false);
-
 			const int GROUP_SIZE = 1024;
 			const int WORK_SIZE = (n + 2 * GROUP_SIZE - 1) / (2 * GROUP_SIZE) * (2 * GROUP_SIZE);
 


### PR DESCRIPTION
Mandelbrot ([по спекам](https://www.techpowerup.com/gpu-specs/geforce-gt-730.c1988) должно быть 690 GFLOPS, по факту 190):

```
OpenCL devices:
  Device #0: GPU. GeForce GT 730. Total memory: 1024 Mb
  Device #1: CPU. Intel(R) Core(TM) i7-4770K CPU @ 3.50GHz. Intel(R) Corporation. Total memory: 16327 Mb
Using device #0: GPU. GeForce GT 730. Total memory: 1024 Mb
CPU: 0.521667+-0.0157656 s
CPU: 19.1693 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.0528333+-0.00106719 s
GPU: 189.274 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.942446%

OpenCL devices:
  Device #0: GPU. GeForce GT 730. Total memory: 1024 Mb
  Device #1: CPU. Intel(R) Core(TM) i7-4770K CPU @ 3.50GHz. Intel(R) Corporation. Total memory: 16327 Mb
Using device #1: CPU. Intel(R) Core(TM) i7-4770K CPU @ 3.50GHz. Intel(R) Corporation. Total memory: 16327 Mb
CPU: 0.5745+-0.0215697 s
CPU: 17.4064 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.147333+-0.0020548 s
GPU: 67.8733 GFlops
    Real iterations fraction: 56.2653%
GPU vs CPU average results difference: 0.947166%
```

Sum (карта тормозит, а OpenCL на процессоре быстрее процессора, но медленнее OMP):

```
CPU:     0.0301667+-0.000372678 s
CPU:     3314.92 millions/s
CPU OMP: 0.0396667+-0.0262848 s
CPU OMP: 2521.01 millions/s
OpenCL devices:
  Device #0: GPU. GeForce GT 730. Total memory: 1024 Mb
  Device #1: CPU. Intel(R) Core(TM) i7-4770K CPU @ 3.50GHz. Intel(R) Corporation. Total memory: 16327 Mb
Using device #0: GPU. GeForce GT 730. Total memory: 1024 Mb
GPU: 0.102333+-0.00179505 s
GPU: 977.199 millions/s

CPU:     0.0286667+-0.000745356 s
CPU:     3488.37 millions/s
CPU OMP: 0.065+-0.0403691 s
CPU OMP: 1538.46 millions/s

OpenCL devices:
  Device #0: GPU. GeForce GT 730. Total memory: 1024 Mb
  Device #1: CPU. Intel(R) Core(TM) i7-4770K CPU @ 3.50GHz. Intel(R) Corporation. Total memory: 16327 Mb
Using device #1: CPU. Intel(R) Core(TM) i7-4770K CPU @ 3.50GHz. Intel(R) Corporation. Total memory: 16327 Mb
GPU: 0.0676667+-0.000745356 s
GPU: 1477.83 millions/s
```

Max prefix sum (тормозит всё):

```
OpenCL devices:
  Device #0: GPU. GeForce GT 730. Total memory: 1024 Mb
  Device #1: CPU. Intel(R) Core(TM) i7-4770K CPU @ 3.50GHz. Intel(R) Corporation. Total memory: 16327 Mb
Using device #0: GPU. GeForce GT 730. Total memory: 1024 Mb
______________________________________________
n=2 values in range: [-1023; 1023]
Max prefix sum: 0 on prefix [0; 0)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 0.002 millions/s
______________________________________________
n=4 values in range: [-1023; 1023]
Max prefix sum: 776 on prefix [0; 1)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 0.004 millions/s
______________________________________________
n=8 values in range: [-1023; 1023]
Max prefix sum: 0 on prefix [0; 0)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 0.008 millions/s
______________________________________________
n=16 values in range: [-1023; 1023]
Max prefix sum: 1562 on prefix [0; 6)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 0.016 millions/s
______________________________________________
n=32 values in range: [-1023; 1023]
Max prefix sum: 6550 on prefix [0; 22)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 0.032 millions/s
______________________________________________
n=64 values in range: [-1023; 1023]
Max prefix sum: 0 on prefix [0; 0)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000833333+-0.000372678 s
GPU: 0.0768 millions/s
______________________________________________
n=128 values in range: [-1023; 1023]
Max prefix sum: 4191 on prefix [0; 34)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 0.128 millions/s
______________________________________________
n=256 values in range: [-1023; 1023]
Max prefix sum: 1093 on prefix [0; 4)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 0.256 millions/s
______________________________________________
n=512 values in range: [-1023; 1023]
Max prefix sum: 7395 on prefix [0; 316)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 0.512 millions/s
______________________________________________
n=1024 values in range: [-1023; 1023]
Max prefix sum: 4662 on prefix [0; 323)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 1.024 millions/s
______________________________________________
n=2048 values in range: [-1023; 1023]
Max prefix sum: 3486 on prefix [0; 55)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 2.048 millions/s
______________________________________________
n=4096 values in range: [-1023; 1023]
Max prefix sum: 6013 on prefix [0; 208)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 4.096 millions/s
______________________________________________
n=8192 values in range: [-1023; 1023]
Max prefix sum: 75294 on prefix [0; 6579)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 8.192 millions/s
______________________________________________
n=16384 values in range: [-1023; 1023]
Max prefix sum: 92146 on prefix [0; 12399)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.00116667+-0.000372678 s
GPU: 14.0434 millions/s
______________________________________________
n=32768 values in range: [-1023; 1023]
Max prefix sum: 78744 on prefix [0; 3221)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.00166667+-0.000471405 s
GPU: 19.6608 millions/s
______________________________________________
n=65536 values in range: [-1023; 1023]
Max prefix sum: 56352 on prefix [0; 8758)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.002+-0 s
GPU: 32.768 millions/s
______________________________________________
n=131072 values in range: [-1023; 1023]
Max prefix sum: 114622 on prefix [0; 10080)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.003+-4.1159e-11 s
GPU: 43.6907 millions/s
______________________________________________
n=262144 values in range: [-1023; 1023]
Max prefix sum: 228982 on prefix [0; 97875)
CPU: 0.000166667+-0.000372678 s
CPU: 1572.86 millions/s
GPU: 0.0045+-0.0005 s
GPU: 58.2542 millions/s
______________________________________________
n=524288 values in range: [-1023; 1023]
Max prefix sum: 771285 on prefix [0; 524288)
CPU: 0.000666667+-0.000471405 s
CPU: 786.432 millions/s
GPU: 0.00683333+-0.000372678 s
GPU: 76.7251 millions/s
______________________________________________
n=1048576 values in range: [-1023; 1023]
Max prefix sum: 378485 on prefix [0; 836658)
CPU: 0.001+-0 s
CPU: 1048.58 millions/s
GPU: 0.0111667+-0.000372678 s
GPU: 93.9023 millions/s
______________________________________________
n=2097152 values in range: [-1023; 1023]
Max prefix sum: 1625146 on prefix [0; 1558997)
CPU: 0.00233333+-0.000471405 s
CPU: 898.779 millions/s
GPU: 0.021+-0 s
GPU: 99.8644 millions/s
______________________________________________
n=4194304 values in range: [-511; 511]
Max prefix sum: 315064 on prefix [0; 4115605)
CPU: 0.005+-0 s
CPU: 838.861 millions/s
GPU: 0.0396667+-0.000471405 s
GPU: 105.739 millions/s
______________________________________________
n=8388608 values in range: [-255; 255]
Max prefix sum: 55893 on prefix [0; 20879)
CPU: 0.0108333+-0.000372678 s
CPU: 774.333 millions/s
GPU: 0.0921667+-0.00843439 s
GPU: 91.0156 millions/s
______________________________________________
n=16777216 values in range: [-127; 127]
Max prefix sum: 118369 on prefix [0; 652799)
CPU: 0.0208333+-0.000372678 s
CPU: 805.306 millions/s
GPU: 0.154333+-0.00298142 s
GPU: 108.708 millions/s

OpenCL devices:
  Device #0: GPU. GeForce GT 730. Total memory: 1024 Mb
  Device #1: CPU. Intel(R) Core(TM) i7-4770K CPU @ 3.50GHz. Intel(R) Corporation. Total memory: 16327 Mb
Using device #1: CPU. Intel(R) Core(TM) i7-4770K CPU @ 3.50GHz. Intel(R) Corporation. Total memory: 16327 Mb
______________________________________________
n=2 values in range: [-1023; 1023]
Max prefix sum: 0 on prefix [0; 0)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000166667+-0.000372678 s
GPU: 0.012 millions/s
______________________________________________
n=4 values in range: [-1023; 1023]
Max prefix sum: 776 on prefix [0; 1)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0+-0 s
GPU: inf millions/s
______________________________________________
n=8 values in range: [-1023; 1023]
Max prefix sum: 0 on prefix [0; 0)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000166667+-0.000372678 s
GPU: 0.048 millions/s
______________________________________________
n=16 values in range: [-1023; 1023]
Max prefix sum: 1562 on prefix [0; 6)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0+-0 s
GPU: inf millions/s
______________________________________________
n=32 values in range: [-1023; 1023]
Max prefix sum: 6550 on prefix [0; 22)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000166667+-0.000372678 s
GPU: 0.192 millions/s
______________________________________________
n=64 values in range: [-1023; 1023]
Max prefix sum: 0 on prefix [0; 0)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0+-0 s
GPU: inf millions/s
______________________________________________
n=128 values in range: [-1023; 1023]
Max prefix sum: 4191 on prefix [0; 34)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000166667+-0.000372678 s
GPU: 0.768 millions/s
______________________________________________
n=256 values in range: [-1023; 1023]
Max prefix sum: 1093 on prefix [0; 4)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000166667+-0.000372678 s
GPU: 1.536 millions/s
______________________________________________
n=512 values in range: [-1023; 1023]
Max prefix sum: 7395 on prefix [0; 316)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0+-0 s
GPU: inf millions/s
______________________________________________
n=1024 values in range: [-1023; 1023]
Max prefix sum: 4662 on prefix [0; 323)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0+-0 s
GPU: inf millions/s
______________________________________________
n=2048 values in range: [-1023; 1023]
Max prefix sum: 3486 on prefix [0; 55)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000166667+-0.000372678 s
GPU: 12.288 millions/s
______________________________________________
n=4096 values in range: [-1023; 1023]
Max prefix sum: 6013 on prefix [0; 208)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000166667+-0.000372678 s
GPU: 24.576 millions/s
______________________________________________
n=8192 values in range: [-1023; 1023]
Max prefix sum: 75294 on prefix [0; 6579)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000333333+-0.000471405 s
GPU: 24.576 millions/s
______________________________________________
n=16384 values in range: [-1023; 1023]
Max prefix sum: 92146 on prefix [0; 12399)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.000666667+-0.000471405 s
GPU: 24.576 millions/s
______________________________________________
n=32768 values in range: [-1023; 1023]
Max prefix sum: 78744 on prefix [0; 3221)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 32.768 millions/s
______________________________________________
n=65536 values in range: [-1023; 1023]
Max prefix sum: 56352 on prefix [0; 8758)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.001+-0 s
GPU: 65.536 millions/s
______________________________________________
n=131072 values in range: [-1023; 1023]
Max prefix sum: 114622 on prefix [0; 10080)
CPU: 0+-0 s
CPU: inf millions/s
GPU: 0.00116667+-0.000372678 s
GPU: 112.347 millions/s
______________________________________________
n=262144 values in range: [-1023; 1023]
Max prefix sum: 228982 on prefix [0; 97875)
CPU: 0.000166667+-0.000372678 s
CPU: 1572.86 millions/s
GPU: 0.002+-0 s
GPU: 131.072 millions/s
______________________________________________
n=524288 values in range: [-1023; 1023]
Max prefix sum: 771285 on prefix [0; 524288)
CPU: 0.000666667+-0.000471405 s
CPU: 786.432 millions/s
GPU: 0.00416667+-0.000372678 s
GPU: 125.829 millions/s
______________________________________________
n=1048576 values in range: [-1023; 1023]
Max prefix sum: 378485 on prefix [0; 836658)
CPU: 0.001+-0 s
CPU: 1048.58 millions/s
GPU: 0.00766667+-0.000745356 s
GPU: 136.771 millions/s
______________________________________________
n=2097152 values in range: [-1023; 1023]
Max prefix sum: 1625146 on prefix [0; 1558997)
CPU: 0.00266667+-0.000471405 s
CPU: 786.432 millions/s
GPU: 0.0188333+-0.000687184 s
GPU: 111.353 millions/s
______________________________________________
n=4194304 values in range: [-511; 511]
Max prefix sum: 315064 on prefix [0; 4115605)
CPU: 0.005+-0 s
CPU: 838.861 millions/s
GPU: 0.0373333+-0.000942809 s
GPU: 112.347 millions/s
______________________________________________
n=8388608 values in range: [-255; 255]
Max prefix sum: 55893 on prefix [0; 20879)
CPU: 0.0103333+-0.000471405 s
CPU: 811.801 millions/s
GPU: 0.0676667+-0.000471405 s
GPU: 123.97 millions/s
______________________________________________
n=16777216 values in range: [-127; 127]
Max prefix sum: 118369 on prefix [0; 652799)
CPU: 0.0215+-0.000763763 s
CPU: 780.336 millions/s
GPU: 0.145167+-0.00279384 s
GPU: 115.572 millions/s
```